### PR TITLE
build(pkg)!: export cjs and module format

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,15 @@
-
 {
-  "presets": [
-    ["@babel/preset-react"],
-    ["@babel/preset-env"]
-  ],
-  "plugins": [
-
-  ]
+  "presets": [["@babel/preset-react"], ["@babel/preset-env"]],
+  "env": {
+    "esm": {
+      "presets": [
+        [
+          "@babel/preset-env",
+          {
+            "modules": false
+          }
+        ]
+      ]
+    }
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .cache
+cjs
 coverage
 dist
+esm
 example/dist
 node_modules

--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
   "name": "@socialgouv/react-departements",
   "description": "Une carte de France où certains departements peuvent être colorés.",
   "version": "2.1.1",
-  "main": "dist/index.js",
-  "module": "src/index.js",
+  "main": "cjs/index.js",
+  "module": "esm/index.js",
+  "browser": "dist/index.js",
   "license": "Apache-2.0",
   "files": [
     "README.md",
+    "cjs",
     "dist",
-    "src"
+    "esm"
   ],
   "dependencies": {
     "react-svgmt": "^1.1.9"
@@ -41,8 +43,11 @@
     "clean:demo": "rm -rf ./example/dist",
     "start": "parcel watch ./src/index.js --out-dir ./dist",
     "start:demo": "parcel ./example/src/index.html --out-dir ./example/dist",
-    "build": "parcel build ./src/index.js --global minimum-parcel-lib",
+    "build": "yarn run build:browser && yarn run build:cjs && yarn run build:esm",
+    "build:browser": "parcel build ./src/index.js --global minimum-parcel-lib",
+    "build:cjs": "BABEL_ENV=cjs babel src --out-dir cjs",
     "build:demo": "parcel build ./example/src/index.html --out-dir ./example/dist --public-url ./",
+    "build:esm": "BABEL_ENV=esm babel src --out-dir esm",
     "deploy": "gh-pages -d ./example/dist -r https://gitlab-ci-token:$GH_TOKEN@github.com/SocialGouv/react-departements.git"
   }
 }


### PR DESCRIPTION
<img src=https://media.giphy.com/media/5wFUxSV2R7wi7NJX8x/giphy.gif width=693>

---

Help supporting treeshaking

**BREAKING CHANGE**: export cjs format as main

As most build tools can tree shake commonjs format, I would argue that we should provide the cjs format as default.
The previous bundle is available under the `browser` entry.